### PR TITLE
CDSE endpoint for download.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Unreleased
 
+**Added**
+- CDSE (Copernicus Data Space Ecosystem) as an alternative download source for Sentinel-1 SLC granules via `--download-source CDSE` CLI option or `download_source: CDSE` in config.
+- New `_cdse.py` module with CDSE credential handling, OAuth2 token acquisition, OData catalog search, and download with retry logic (supports both compressed and natively compressed CDSE archives).
+- Interactive CDSE credential setup in `_netrc.py` (via environment variables, `~/.netrc`, or interactive prompt).
+- Sentinel-1C support in unzip glob patterns.
 
 # [0.2.0](https://github.com/opera-adt/dolphin/compare/v0.2.0...v0.3.0) - 2023-08-23
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,37 @@ conda activate sweets-env
 python -m pip install .
 ```
 
+## Setup
+
+You need a `~/.netrc` file with NASA Earthdata credentials to download data from ASF:
+
+```
+machine urs.earthdata.nasa.gov
+    login <username>
+    password <password>
+```
+
+Register at https://urs.earthdata.nasa.gov/users/new if you don't have an account.
+
+### Optional: CDSE credentials
+
+To download Sentinel-1 SLC granules from the [Copernicus Data Space Ecosystem (CDSE)](https://dataspace.copernicus.eu/) instead of ASF, you need CDSE credentials. These can be provided in one of two ways:
+
+- Add an entry to your `~/.netrc` file:
+  ```
+  machine dataspace.copernicus.eu
+      login <cdse-username>
+      password <cdse-password>
+  ```
+- Or set environment variables:
+  ```bash
+  export CDSE_USERNAME=<cdse-username>
+  export CDSE_PASSWORD=<cdse-password>
+  ```
+
+A free CDSE account can be registered at [dataspace.copernicus.eu](https://dataspace.copernicus.eu/).
+
+
 ## Usage
 
 From the command line, installing will create a `sweets` executable. You can run `sweets --help` to see the available options.
@@ -56,6 +87,19 @@ Then you can kick off the workflow using
 sweets run sweets_config.yaml
 ```
 
+### Using CDSE for Sentinel-1 Download
+
+By default, Sentinel-1 SLC granules are downloaded from the [Alaska Satellite Facility (ASF)](https://asf.alaska.edu/). As an alternative, particularly suited for European users or those operating within the European cloud ecosystem, granules can be downloaded from [CDSE](https://dataspace.copernicus.eu/) by passing `--download-source CDSE`:
+
+```bash
+sweets config --bbox -102.2 32.15 -102.1 32.22 --start 2022-12-15 --end 2022-12-29 --track 78 --download-source CDSE
+```
+
+Or in a YAML config file, set:
+```yaml
+download_source: CDSE
+```
+
 ### Configuration from Python
 
 Alternatively, you can configure everything in python:
@@ -65,6 +109,16 @@ bbox = (-102.3407, 31.9909, -101.9407, 32.3909)
 start = "2020-01-01"  # can be strings or datetime objects
 track = 78
 w = Workflow(bbox=bbox, asf_query=dict(start=start, end=end, relativeOrbit=track))
+w.run()
+```
+
+To use CDSE for downloads:
+```python
+w = Workflow(
+    bbox=bbox,
+    download_source="CDSE",
+    asf_query=dict(start=start, end=end, relativeOrbit=track),
+)
 w.run()
 ```
 

--- a/src/sweets/_cdse.py
+++ b/src/sweets/_cdse.py
@@ -1,0 +1,325 @@
+"""Download Sentinel-1 SLC granules from the Copernicus Data Space Ecosystem (CDSE).
+
+This module provides an alternative to the ASF-based download in download.py.
+It searches the CDSE OData catalog by granule name and downloads the product zip.
+
+CDSE credentials (username/password) are required and can be provided via:
+  - Environment variables: CDSE_USERNAME and CDSE_PASSWORD
+  - The ~/.netrc file with machine: dataspace.copernicus.eu
+
+References:
+  - https://documentation.dataspace.copernicus.eu/APIs/OData.html
+  - https://documentation.dataspace.copernicus.eu/APIs/Token.html
+"""
+
+from __future__ import annotations
+
+import netrc
+import os
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import Optional
+
+import requests
+
+from ._log import get_log
+from ._types import Filename
+
+logger = get_log(__name__)
+
+CDSE_HOST = "dataspace.copernicus.eu"
+CDSE_TOKEN_URL = (
+    "https://identity.dataspace.copernicus.eu"
+    "/auth/realms/CDSE/protocol/openid-connect/token"
+)
+CDSE_ODATA_URL = "https://catalogue.dataspace.copernicus.eu/odata/v1/Products"
+CDSE_DOWNLOAD_URL = "https://download.dataspace.copernicus.eu/odata/v1/Products"
+
+# Retry settings
+MAX_RETRIES = 3
+RETRY_START_WAIT = 10  # seconds
+RETRY_INCREMENT = 10  # seconds
+
+
+def get_cdse_credentials(
+    username: Optional[str] = None,
+    password: Optional[str] = None,
+) -> tuple[str, str]:
+    """Resolve CDSE credentials from arguments, environment, or ~/.netrc.
+
+    Parameters
+    ----------
+    username : str, optional
+        CDSE username. Falls back to CDSE_USERNAME env var, then ~/.netrc.
+    password : str, optional
+        CDSE password. Falls back to CDSE_PASSWORD env var, then ~/.netrc.
+
+    Returns
+    -------
+    tuple[str, str]
+        (username, password)
+    """
+    if username and password:
+        return username, password
+
+    env_user = os.getenv("CDSE_USERNAME")
+    env_pass = os.getenv("CDSE_PASSWORD")
+    if env_user and env_pass:
+        return env_user, env_pass
+
+    try:
+        nrc = netrc.netrc()
+        auth = nrc.authenticators(CDSE_HOST)
+        if auth:
+            return auth[0], auth[2]
+    except (FileNotFoundError, netrc.NetrcParseError):
+        pass
+
+    raise ValueError(
+        "CDSE credentials not found. Provide them via:\n"
+        "  1. CDSE_USERNAME and CDSE_PASSWORD environment variables\n"
+        "  2. ~/.netrc entry for machine dataspace.copernicus.eu"
+    )
+
+
+def ensure_cdse_credentials(
+    username: Optional[str] = None,
+    password: Optional[str] = None,
+    host: str = CDSE_HOST,
+) -> None:
+    """Ensure CDSE credentials are available in ~/.netrc.
+
+    CDSE username and password may be provided by, in order of preference:
+       * ``CDSE_USERNAME`` and ``CDSE_PASSWORD`` environment variables
+       * ``~/.netrc`` entry for machine dataspace.copernicus.eu
+
+    If credentials are provided via env vars but ~/.netrc does not
+    contain an entry for CDSE, the entry will be appended to ~/.netrc.
+    """
+    if username is None:
+        username = os.getenv("CDSE_USERNAME")
+    if password is None:
+        password = os.getenv("CDSE_PASSWORD")
+
+    netrc_file = Path.home() / ".netrc"
+
+    cdse_in_netrc = False
+    if netrc_file.exists():
+        try:
+            nrc = netrc.netrc(netrc_file)
+            if nrc.authenticators(host):
+                cdse_in_netrc = True
+        except netrc.NetrcParseError:
+            pass
+
+    if username and password and not cdse_in_netrc:
+        with open(netrc_file, "a") as f:
+            f.write(f"\nmachine {host} login {username} password {password}\n")
+        netrc_file.chmod(0o600)
+
+    try:
+        get_cdse_credentials(username, password)
+    except ValueError:
+        raise ValueError(
+            f"Please provide valid CDSE credentials via {netrc_file}, "
+            f"the CDSE_USERNAME and CDSE_PASSWORD environment variables, "
+            f"or add an entry for machine {host} to your ~/.netrc file.\n"
+            f"Register for a free account at https://dataspace.copernicus.eu/"
+        )
+
+
+def get_cdse_access_token(username: str, password: str) -> str:
+    """Obtain an access token from the CDSE identity provider."""
+    data = {
+        "grant_type": "password",
+        "username": username,
+        "password": password,
+        "client_id": "cdse-public",
+    }
+    response = requests.post(CDSE_TOKEN_URL, data=data, timeout=60)
+    response.raise_for_status()
+    return response.json()["access_token"]
+
+
+def search_cdse_by_granule_name(granule_name: str) -> dict:
+    """Search the CDSE OData catalog for a Sentinel-1 SLC by granule name.
+
+    Parameters
+    ----------
+    granule_name : str
+        Sentinel-1 granule / scene name (without .SAFE or .zip extension).
+
+    Returns
+    -------
+    dict
+        Product entry from the CDSE OData response containing ``Id`` and ``Name``.
+
+    Raises
+    ------
+    LookupError
+        If the product is not found on CDSE.
+    """
+    granule_name = granule_name.replace(".zip", "").replace(".SAFE", "")
+    safe_name = f"{granule_name}.SAFE"
+    query = f"{CDSE_ODATA_URL}?$filter=Name eq '{safe_name}'"
+
+    response = requests.get(query, timeout=120)
+    response.raise_for_status()
+    results = response.json().get("value", [])
+
+    if not results:
+        raise LookupError(
+            f"Product '{safe_name}' not found in CDSE catalog. Query: {query}"
+        )
+    return results[0]
+
+
+def download_single_slc_from_cdse(
+    granule_name: str,
+    access_token: str,
+    output_dir: Filename = ".",
+    max_retries: int = MAX_RETRIES,
+) -> str:
+    """Download a single Sentinel-1 SLC product from CDSE.
+
+    Tries the compressed endpoint (/$zip) first, then falls back to
+    the natively compressed archive (/$value).
+
+    Parameters
+    ----------
+    granule_name : str
+        Sentinel-1 granule / scene name.
+    access_token : str
+        CDSE bearer access token.
+    output_dir : Filename
+        Directory to save the downloaded zip file.
+    max_retries : int
+        Number of download attempts before raising an error.
+
+    Returns
+    -------
+    str
+        The filename of the downloaded zip file.
+    """
+    granule_name = granule_name.replace(".zip", "").replace(".SAFE", "")
+
+    product = search_cdse_by_granule_name(granule_name)
+    product_id = product["Id"]
+
+    # Try compressed endpoint first (/$zip), fall back to /$value
+    download_url_zip = f"{CDSE_DOWNLOAD_URL}({product_id})/$zip"
+    download_url_value = f"{CDSE_DOWNLOAD_URL}({product_id})/$value"
+    headers = {"Authorization": f"Bearer {access_token}"}
+
+    out_filename = f"{granule_name}.zip"
+    out_path = Path(output_dir) / out_filename
+
+    def _do_download(url: str) -> str:
+        """Perform the actual download from a given URL."""
+        response = requests.get(
+            url,
+            headers=headers,
+            stream=True,
+            timeout=600,
+        )
+        response.raise_for_status()
+
+        with open(out_path, "wb") as f:
+            for chunk in response.iter_content(chunk_size=8192 * 16):
+                if chunk:
+                    f.write(chunk)
+
+        if out_path.stat().st_size == 0:
+            out_path.unlink(missing_ok=True)
+            raise requests.RequestException("Downloaded file is empty")
+
+        logger.info(
+            f"Downloaded {out_filename} from CDSE"
+            f" ({out_path.stat().st_size / 1e6:.1f} MB)"
+        )
+        return out_filename
+
+    last_exc: Optional[Exception] = None
+    for attempt in range(1, max_retries + 1):
+        logger.info(f"CDSE download attempt #{attempt} for {granule_name}")
+        try:
+            try:
+                return _do_download(download_url_zip)
+            except requests.HTTPError as e:
+                out_path.unlink(missing_ok=True)
+                if e.response is not None and e.response.status_code == 404:
+                    logger.info(
+                        "Compressed format not available, falling back to"
+                        " uncompressed..."
+                    )
+                    try:
+                        return _do_download(download_url_value)
+                    except requests.RequestException:
+                        out_path.unlink(missing_ok=True)
+                        raise
+                raise
+            except requests.RequestException:
+                out_path.unlink(missing_ok=True)
+                raise
+        except Exception as exc:
+            last_exc = exc
+            wait_time = RETRY_START_WAIT + RETRY_INCREMENT * (attempt - 1)
+            if attempt < max_retries:
+                logger.warning(
+                    f"Attempt #{attempt} failed: {exc}. "
+                    f"Waiting {wait_time}s before retry..."
+                )
+                import time
+
+                time.sleep(wait_time)
+
+    raise RuntimeError(
+        f"Failed to download {granule_name} from CDSE after {max_retries} attempts"
+    ) from last_exc
+
+
+def download_slcs_from_cdse(
+    slc_ids: list[str],
+    username: Optional[str] = None,
+    password: Optional[str] = None,
+    output_dir: Filename = ".",
+    max_workers: int = 3,
+) -> list[str]:
+    """Download multiple Sentinel-1 SLC granules from CDSE.
+
+    Parameters
+    ----------
+    slc_ids : list[str]
+        List of Sentinel-1 granule / scene names (ASF-style).
+    username : str, optional
+        CDSE username. Resolved from env/netrc if not provided.
+    password : str, optional
+        CDSE password. Resolved from env/netrc if not provided.
+    output_dir : Filename
+        Directory to save downloaded zip files.
+    max_workers : int
+        Number of parallel download threads.
+
+    Returns
+    -------
+    list[str]
+        List of downloaded zip filenames.
+    """
+    cdse_user, cdse_pass = get_cdse_credentials(username, password)
+    access_token = get_cdse_access_token(cdse_user, cdse_pass)
+
+    Path(output_dir).mkdir(parents=True, exist_ok=True)
+
+    def _download_one(slc_id: str) -> str:
+        return download_single_slc_from_cdse(
+            slc_id,
+            access_token=access_token,
+            output_dir=str(output_dir),
+        )
+
+    n = len(slc_ids)
+    logger.info(f"Downloading {n} SLCs from CDSE to {output_dir}")
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        results = list(executor.map(_download_one, slc_ids))
+
+    return results

--- a/src/sweets/_netrc.py
+++ b/src/sweets/_netrc.py
@@ -8,6 +8,7 @@ from ._log import console
 from ._types import Filename
 
 NASA_HOST = "urs.earthdata.nasa.gov"
+CDSE_HOST = "dataspace.copernicus.eu"
 
 
 def setup_nasa_netrc(netrc_file: Filename = "~/.netrc"):
@@ -67,4 +68,77 @@ def _get_username_pass():
 
     username = console.input("Username: ")
     password = console.input("Password (will not be displayed): ", password=True)
+    return username, password
+
+
+def setup_cdse_netrc(netrc_file: Filename = "~/.netrc"):
+    """Prompt user for CDSE username/password if not in ~/.netrc or env vars."""
+    netrc_file = Path(netrc_file).expanduser()
+
+    # Check environment variables first
+    env_user = os.getenv("CDSE_USERNAME")
+    env_pass = os.getenv("CDSE_PASSWORD")
+    if env_user and env_pass:
+        # Ensure they are in .netrc too
+        _ensure_netrc_entry(netrc_file, CDSE_HOST, env_user, env_pass)
+        return
+
+    try:
+        n = netrc.netrc(netrc_file)
+        has_correct_permission = _file_is_0600(netrc_file)
+        if not has_correct_permission:
+            os.chmod(netrc_file, 0o600)
+        _has_cdse_entry = (
+            CDSE_HOST in n.hosts
+            and n.authenticators(CDSE_HOST)[0]  # type: ignore
+            and n.authenticators(CDSE_HOST)[2]  # type: ignore
+        )
+        if _has_cdse_entry:
+            return
+    except FileNotFoundError:
+        console.print("No ~/.netrc file found, creating one.", style="bold")
+        Path(netrc_file).write_text("")
+        os.chmod(netrc_file, 0o600)
+        n = netrc.netrc(netrc_file)
+
+    username, password = _get_cdse_username_pass()
+    n.hosts[CDSE_HOST] = (username, "", password)
+    console.print(f"Saving credentials to {netrc_file} (machine={CDSE_HOST}).")
+    with open(netrc_file, "w") as f:
+        f.write(str(n))
+    os.chmod(netrc_file, 0o600)
+
+
+def _ensure_netrc_entry(
+    netrc_file: Path, host: str, username: str, password: str
+):
+    """Append a netrc entry for `host` if it doesn't already exist."""
+    try:
+        if netrc_file.exists():
+            nrc = netrc.netrc(netrc_file)
+            if nrc.authenticators(host):
+                return
+    except netrc.NetrcParseError:
+        pass
+
+    with open(netrc_file, "a") as f:
+        f.write(f"\nmachine {host} login {username} password {password}\n")
+    netrc_file.chmod(0o600)
+
+
+def _get_cdse_username_pass():
+    """If CDSE netrc is not set up, get username/password via command line."""
+    console.print(
+        Panel(
+            "Please enter CDSE credentials to download data from the "
+            "Copernicus Data Space Ecosystem."
+        )
+    )
+    console.print(
+        "See https://dataspace.copernicus.eu/ for signup info",
+        style="link https://dataspace.copernicus.eu/",
+    )
+
+    username = console.input("CDSE Username (email): ")
+    password = console.input("CDSE Password (will not be displayed): ", password=True)
     return username, password

--- a/src/sweets/_netrc.py
+++ b/src/sweets/_netrc.py
@@ -109,9 +109,7 @@ def setup_cdse_netrc(netrc_file: Filename = "~/.netrc"):
     os.chmod(netrc_file, 0o600)
 
 
-def _ensure_netrc_entry(
-    netrc_file: Path, host: str, username: str, password: str
-):
+def _ensure_netrc_entry(netrc_file: Path, host: str, username: str, password: str):
     """Append a netrc entry for `host` if it doesn't already exist."""
     try:
         if netrc_file.exists():

--- a/src/sweets/_unzip.py
+++ b/src/sweets/_unzip.py
@@ -38,10 +38,10 @@ def unzip_all(
     n_workers: int = 4,
 ) -> List[Path]:
     """Find all .zips and unzip them, skipping overwrites."""
-    zip_files = list(Path(path).glob("S1[AB]_*IW*.zip"))
+    zip_files = list(Path(path).glob("S1[ABC]_*IW*.zip"))
     logger.info(f"Found {len(zip_files)} zip files to unzip")
 
-    existing_safes = list(Path(path).glob("S1[AB]_*IW*.SAFE"))
+    existing_safes = list(Path(path).glob("S1[ABC]_*IW*.SAFE"))
     logger.info(f"Found {len(existing_safes)} SAFE files already unzipped")
 
     # Skip if already unzipped

--- a/src/sweets/cli.py
+++ b/src/sweets/cli.py
@@ -88,6 +88,18 @@ def _get_cli_args() -> dict:
             " If None, will store in `data/` "
         ),
     )
+    base.add_argument(
+        "--download-source",
+        type=str,
+        choices=["ASF", "CDSE"],
+        default="ASF",
+        help=(
+            "Source for downloading Sentinel-1 SLC granules. "
+            "'ASF' uses Alaska Satellite Facility (default). "
+            "'CDSE' uses Copernicus Data Space Ecosystem "
+            "(requires CDSE_USERNAME/CDSE_PASSWORD env vars or ~/.netrc)."
+        ),
+    )
 
     interferogram_options = config_parser.add_argument_group("interferogram_options")
     interferogram_options.add_argument(
@@ -164,7 +176,7 @@ def _get_cli_args() -> dict:
         default=1,
         help=(
             "If > 1, will skip earlier steps of the workflow. Step: "
-            "1. Download RSLC data from ASF. 2. Create GSLCs. "
+            "1. Download RSLC data from ASF/CDSE. 2. Create GSLCs. "
             "3. Create burst interfereograms. "
             "4. Stitch burst interferograms into one per date. "
             "5. Unwrap. "

--- a/src/sweets/core.py
+++ b/src/sweets/core.py
@@ -77,8 +77,9 @@ class Workflow(YamlModel):
     skip_download_if_exists: bool = Field(
         True,
         description=(
-            "Don't re-query ASF/CDSE if there's any existing data in the download"
-            " directory. Otherwise, will re-query and re-download missing files."
+            "Skip downloading files that already exist in the download directory."
+            " ASF/CDSE is always queried first so that only truly missing files"
+            " are fetched."
         ),
     )
     dem_filename: Path = Field(
@@ -329,23 +330,10 @@ class Workflow(YamlModel):
     def _download_rslcs(self) -> list[Path]:
         """Download Sentinel zip files from ASF or CDSE."""
         self.log_dir.mkdir(parents=True, exist_ok=True)
-        # The final name will depend on if we're unzipping or not
-        existing_files = self._get_existing_rslcs()
-
-        if existing_files and self.skip_download_if_exists:
-            logger.info(
-                f"Found {len(existing_files)} existing files in"
-                f" {self.asf_query.out_dir}. Skipping download."
-            )
-            return existing_files
-
-        # If we didn't have any, we need to download them
-        # TODO: how should we handle partial/failed downloads... do we really
-        # want to re-search for them each time?
-        # Maybe there can be a "force" flag to re-download everything?
-        # or perhaps an API search, then if the number matches, we can skip
-        # rather than let aria2c start and do the checksums
-        return self.asf_query.download(log_dir=self.log_dir)
+        return self.asf_query.download(
+            log_dir=self.log_dir,
+            skip_if_exists=self.skip_download_if_exists,
+        )
 
     @log_runtime
     def _geocode_slcs(self, slc_files, dem_file, burst_db_file):

--- a/src/sweets/core.py
+++ b/src/sweets/core.py
@@ -22,7 +22,7 @@ from ._burst_db import get_burst_db
 from ._geocode_slcs import create_config_files, run_geocode, run_static_layers
 from ._geometry import stitch_geometry
 from ._log import get_log, log_runtime
-from ._netrc import setup_nasa_netrc
+from ._netrc import setup_cdse_netrc, setup_nasa_netrc
 from ._orbit import download_orbits
 from ._types import Filename
 from .dem import create_dem, create_water_mask
@@ -65,12 +65,20 @@ class Workflow(YamlModel):
     )
 
     asf_query: ASFQuery
+    download_source: Literal["ASF", "CDSE"] = Field(
+        "ASF",
+        description=(
+            "Source for downloading Sentinel-1 SLC granules. "
+            "'ASF' uses Alaska Satellite Facility (requires Earthdata credentials). "
+            "'CDSE' uses Copernicus Data Space Ecosystem (requires CDSE credentials "
+            "via CDSE_USERNAME/CDSE_PASSWORD env vars or ~/.netrc)."
+        ),
+    )
     skip_download_if_exists: bool = Field(
         True,
         description=(
-            "Don't re-query ASF if there's any existing data in the download directory."
-            " Otherwise, will re-query and only skip files that match checksums (done"
-            " by aria2)."
+            "Don't re-query ASF/CDSE if there's any existing data in the download"
+            " directory. Otherwise, will re-query and re-download missing files."
         ),
     )
     dem_filename: Path = Field(
@@ -168,6 +176,10 @@ class Workflow(YamlModel):
             values["bbox"] = values["asf_query"]["bbox"]
             if not values.get("bbox") and not values.get("wkt"):
                 raise ValueError("Must specify either `bbox` or `wkt`")
+
+            # Sync download_source to asf_query
+            if "download_source" in values:
+                values["asf_query"]["download_source"] = values["download_source"]
 
         return values
 
@@ -315,7 +327,7 @@ class Workflow(YamlModel):
         )
 
     def _download_rslcs(self) -> list[Path]:
-        """Download Sentinel zip files from ASF."""
+        """Download Sentinel zip files from ASF or CDSE."""
         self.log_dir.mkdir(parents=True, exist_ok=True)
         # The final name will depend on if we're unzipping or not
         existing_files = self._get_existing_rslcs()
@@ -538,6 +550,8 @@ class Workflow(YamlModel):
     def run(self, starting_step: int = 1):
         """Run the workflow."""
         setup_nasa_netrc()
+        if self.download_source == "CDSE":
+            setup_cdse_netrc()
         set_num_threads(self.threads_per_worker)
 
         # First step: data download

--- a/src/sweets/download.py
+++ b/src/sweets/download.py
@@ -254,13 +254,9 @@ class ASFQuery(YamlModel):
         # Always check which files are already on disk and skip them.
         # Even with skip_if_exists=False we avoid re-downloading existing files
         # (wget -nc/-c would also skip them, but this saves the network overhead).
-        existing_stems = {
-            p.stem for p in self.out_dir.iterdir() if p.is_file()
-        }
+        existing_stems = {p.stem for p in self.out_dir.iterdir() if p.is_file()}
         missing_indices = [
-            i
-            for i, f in enumerate(file_names)
-            if f.stem not in existing_stems
+            i for i, f in enumerate(file_names) if f.stem not in existing_stems
         ]
 
         n_total = len(file_names)

--- a/src/sweets/download.py
+++ b/src/sweets/download.py
@@ -233,7 +233,11 @@ class ASFQuery(YamlModel):
             list(executor.map(download_url, enumerate(urls)))
 
     @log_runtime
-    def download(self, log_dir: Filename = Path(".")) -> list[Path]:
+    def download(
+        self,
+        log_dir: Filename = Path("."),
+        skip_if_exists: bool = True,
+    ) -> list[Path]:
         # Start by saving data available as geojson
         # Always query ASF for metadata (even when downloading from CDSE)
         results = self.query_results()
@@ -247,22 +251,47 @@ class ASFQuery(YamlModel):
         self.out_dir.mkdir(parents=True, exist_ok=True)
         file_names = [self.out_dir / f for f in self._file_names(results)]
 
-        if self.download_source == "CDSE":
-            logger.info("Downloading SLCs from CDSE")
-            ensure_cdse_credentials()
-            # Extract granule names from the ASF query results
-            granule_names = [
-                r["properties"]["fileName"].replace(".zip", "").replace(".SAFE", "")
-                for r in results["features"]
-            ]
-            downloaded = download_slcs_from_cdse(
-                slc_ids=granule_names,
-                output_dir=str(self.out_dir),
-            )
-            file_names = [self.out_dir / f for f in downloaded]
-        else:
-            # Default: download from ASF
-            self._download_with_wget(urls, log_dir=log_dir)
+        # Always check which files are already on disk and skip them.
+        # Even with skip_if_exists=False we avoid re-downloading existing files
+        # (wget -nc/-c would also skip them, but this saves the network overhead).
+        existing_stems = {
+            p.stem for p in self.out_dir.iterdir() if p.is_file()
+        }
+        missing_indices = [
+            i
+            for i, f in enumerate(file_names)
+            if f.stem not in existing_stems
+        ]
+
+        n_total = len(file_names)
+        n_existing = n_total - len(missing_indices)
+        logger.info(
+            f"Found {n_existing}/{n_total} files already in {self.out_dir}."
+            f" Downloading {len(missing_indices)} missing files."
+        )
+
+        if missing_indices:
+            if self.download_source == "CDSE":
+                logger.info("Downloading SLCs from CDSE")
+                ensure_cdse_credentials()
+                # Extract granule names for missing files only
+                granule_names = [
+                    results["features"][i]["properties"]["fileName"]
+                    .replace(".zip", "")
+                    .replace(".SAFE", "")
+                    for i in missing_indices
+                ]
+                downloaded = download_slcs_from_cdse(
+                    slc_ids=granule_names,
+                    output_dir=str(self.out_dir),
+                )
+                # Update file_names for newly downloaded
+                for idx, fname in zip(missing_indices, downloaded):
+                    file_names[idx] = self.out_dir / fname
+            else:
+                # Default: download from ASF (only missing URLs)
+                missing_urls = [urls[i] for i in missing_indices]
+                self._download_with_wget(missing_urls, log_dir=log_dir)
 
         if self.unzip:
             # Change to .SAFE extension

--- a/src/sweets/download.py
+++ b/src/sweets/download.py
@@ -1,15 +1,30 @@
 #!/usr/bin/env python
-"""Script for downloading through https://asf.alaska.edu/api/.
+"""Script for downloading Sentinel-1 SLC data from ASF or CDSE.
+
+Supports two download sources:
+- ASF (Alaska Satellite Facility): default, uses wget.
+  Requires ~/.netrc credentials for urs.earthdata.nasa.gov.
+- CDSE (Copernicus Data Space Ecosystem): alternative endpoint.
+  Requires CDSE credentials via env vars or ~/.netrc for dataspace.copernicus.eu.
+
+In both cases, ASF is used for the metadata/spatial search (no credentials needed).
+Only the actual file download requires source-specific credentials.
 
 Base taken from
 https://github.com/scottyhq/isce_notes/blob/master/BatchProcessing.md
 https://github.com/scottstanie/apertools/blob/master/apertools/asfdownload.py
 
-
-You need a .netrc to download:
+ASF download requires a .netrc:
 
 # cat ~/.netrc
 machine urs.earthdata.nasa.gov
+    login CHANGE
+    password CHANGE
+
+CDSE download requires a .netrc (or CDSE_USERNAME/CDSE_PASSWORD env vars):
+
+# cat ~/.netrc
+machine dataspace.copernicus.eu
     login CHANGE
     password CHANGE
 
@@ -36,6 +51,7 @@ from dolphin.workflows.config import YamlModel
 from pydantic import ConfigDict, Field, PrivateAttr, field_validator, model_validator
 from shapely.geometry import box
 
+from ._cdse import download_slcs_from_cdse, ensure_cdse_credentials
 from ._log import get_log, log_runtime
 from ._types import Filename
 from ._unzip import unzip_all
@@ -95,6 +111,15 @@ class ASFQuery(YamlModel):
     unzip: bool = Field(
         False,
         description="Unzip downloaded files into .SAFE directories",
+    )
+    download_source: Literal["ASF", "CDSE"] = Field(
+        "ASF",
+        description=(
+            "Source for downloading Sentinel-1 SLC granules. "
+            "'ASF' uses Alaska Satellite Facility (requires Earthdata credentials). "
+            "'CDSE' uses Copernicus Data Space Ecosystem (requires CDSE credentials "
+            "via CDSE_USERNAME/CDSE_PASSWORD env vars or ~/.netrc)."
+        ),
     )
     _url: str = PrivateAttr()
     model_config = ConfigDict(extra="forbid")
@@ -210,6 +235,7 @@ class ASFQuery(YamlModel):
     @log_runtime
     def download(self, log_dir: Filename = Path(".")) -> list[Path]:
         # Start by saving data available as geojson
+        # Always query ASF for metadata (even when downloading from CDSE)
         results = self.query_results()
         urls = self._get_urls(results)
 
@@ -221,8 +247,22 @@ class ASFQuery(YamlModel):
         self.out_dir.mkdir(parents=True, exist_ok=True)
         file_names = [self.out_dir / f for f in self._file_names(results)]
 
-        # TODO: use aria if available? or just make wget parallel...
-        self._download_with_wget(urls, log_dir=log_dir)
+        if self.download_source == "CDSE":
+            logger.info("Downloading SLCs from CDSE")
+            ensure_cdse_credentials()
+            # Extract granule names from the ASF query results
+            granule_names = [
+                r["properties"]["fileName"].replace(".zip", "").replace(".SAFE", "")
+                for r in results["features"]
+            ]
+            downloaded = download_slcs_from_cdse(
+                slc_ids=granule_names,
+                output_dir=str(self.out_dir),
+            )
+            file_names = [self.out_dir / f for f in downloaded]
+        else:
+            # Default: download from ASF
+            self._download_with_wget(urls, log_dir=log_dir)
 
         if self.unzip:
             # Change to .SAFE extension


### PR DESCRIPTION
This PR adds:
- S1C in list of allowed products.
- adds an CDSE endpoint for downloading SLC instead of ASF. (note search is still supported through ASF, but actual download comes from CDSE.)
- add also the check if files are all downloaded or not (this had a TBD in the code)

@scottstanie might enable some more European users for alternative data access point.