### PR TITLE
CLI: expose all `dolphin` options

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -1382,6 +1382,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-25.3.0-pyh71513ae_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/backoff-2.2.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/blosc-1.21.6-he440d0b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/branca-0.8.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-1.1.0-hb9d3cd8_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-bin-1.1.0-hb9d3cd8_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.1.0-py312h2ec8cdc_2.conda
@@ -1402,14 +1403,20 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/click-plugins-1.1.1.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cligj-0.7.2-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/contourpy-1.3.3-py312hd9148b4_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/dateparser-1.2.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/dav1d-1.2.1-hd590300_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/docstring_parser-0.17.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/eval_type_backport-0.2.2-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/fftw-3.3.10-nompi_hf1063bd_110.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/folium-0.20.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/fonttools-4.59.0-py312h8a5da7c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/freetype-2.13.3-h48d6fc4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/freexl-2.0.0-h9dce30a_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/frozenlist-1.7.0-py312h447239a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.10.3-py312hf50df08_12.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-1.1.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-1.1.3-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/geos-3.13.1-h97f6797_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/geotiff-1.7.4-h239500f_2.conda
@@ -1427,9 +1434,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/imageio-2.37.0-pyhfb79c49_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.7.0-pyhe01879c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/isce3-0.24.4-py312h1234567_5_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/joblib-1.5.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/json-c-0.18-h6688a6e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/jxrlib-1.1-hd590300_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.3-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/kiwisolver-1.4.9-py312h0a2e395_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.21.3-h659f571_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/lazy-loader-0.5-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.17-h717163a_0.conda
@@ -1493,10 +1503,14 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lxml-6.0.0-py312h68d7fa5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lz4-c-1.10.0-h5888daf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lzo-2.10-hd590300_1001.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mapclassify-2.10.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/markupsafe-3.0.3-py312h8a5da7c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.10.5-py312he3d6523_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/minizip-4.0.10-h05a5f5f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/multidict-6.6.3-py312h178313f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/networkx-3.6.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-1.26.4-py312heda63a1_0.conda
@@ -1527,6 +1541,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.12-6_cp312.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2025.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyyaml-6.0.2-py312h178313f_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/qhull-2020.2-h434a139_5.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/rasterio-1.4.3-py312h021bea1_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/rav1e-0.7.1-h8fae777_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8c095d6_2.conda
@@ -1539,6 +1554,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml.clib-0.2.8-py312h66e93f0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sardem-0.11.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/scikit-image-0.26.0-np2py312h4ae17e4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/scikit-learn-1.8.0-np2py312h3226591_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/scipy-1.12.0-py312heda63a1_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sentineleof-0.11.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-80.9.0-pyhff2d567_0.conda
@@ -1560,6 +1576,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/tyro-0.9.28-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tzlocal-5.3-py312h7900ff3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/unicodedata2-16.0.0-py312h66e93f0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/uriparser-0.9.8-hac33072_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
@@ -1568,6 +1585,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xerces-c-3.2.5-h988505b_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.12-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb9d3cd8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2026.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/yamale-5.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h7f98852_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/yarl-1.20.1-py312h178313f_0.conda
@@ -1624,6 +1642,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/attrs-25.3.0-pyh71513ae_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/backoff-2.2.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/blosc-1.21.6-h7dd00d9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/branca-0.8.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-1.1.0-hd74edd7_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-bin-1.1.0-hd74edd7_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-python-1.1.0-py312hde4cb15_2.conda
@@ -1644,14 +1663,20 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/click-plugins-1.1.1.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/cligj-0.7.2-pyhd8ed1ab_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/contourpy-1.3.3-py312ha0dd364_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/cycler-0.12.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/dateparser-1.2.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/dav1d-1.2.1-hb547adb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/docstring_parser-0.17.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/eval_type_backport-0.2.2-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fftw-3.3.10-nompi_h6637ab6_110.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/folium-0.20.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/fonttools-4.59.0-py312h6daa0e5_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/freetype-2.13.3-h1d14073_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/freexl-2.0.0-h3ab3353_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/frozenlist-1.7.0-py312h512c567_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gdal-3.10.3-py312h93ff630_12.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-1.1.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-1.1.3-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/geos-3.13.1-hc9a1286_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/geotiff-1.7.4-h1d7e6e1_2.conda
@@ -1669,8 +1694,11 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/imageio-2.37.0-pyhfb79c49_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-8.7.0-pyhe01879c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/isce3-0.24.4-py312h1234567_5_cpu.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/joblib-1.5.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/json-c-0.18-he4178ee_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/jxrlib-1.1-h93a5062_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/kiwisolver-1.4.9-py312hdc12c9d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/krb5-1.21.3-h237132a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/lazy-loader-0.5-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lcms2-2.17-h7eeda09_0.conda
@@ -1726,10 +1754,14 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lxml-6.0.0-py312hc2c121e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lz4-c-1.10.0-h286801f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/lzo-2.10-h93a5062_1001.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/mapclassify-2.10.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/markupsafe-3.0.3-py312h04c11ed_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/matplotlib-base-3.10.5-py312h05635fa_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/minizip-4.0.10-hff1a8ea_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/multidict-6.6.3-py312hdb8e49c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/munkres-1.1.4-pyh9f0ad1d_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-h5e97a16_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/networkx-3.6.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/numpy-1.26.4-py312h8442bc7_0.conda
@@ -1760,6 +1792,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.12-5_cp312.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytz-2025.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyyaml-6.0.2-py312h998013c_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/qhull-2020.2-h420ef59_5.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rasterio-1.4.3-py312h4623290_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/rav1e-0.7.1-h0716509_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.2-h1d1bf99_2.conda
@@ -1772,6 +1805,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruamel.yaml.clib-0.2.8-py312h0bf5046_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sardem-0.11.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scikit-image-0.26.0-np2py312ha921b1d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scikit-learn-1.8.0-np2py312he5ca3e3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/scipy-1.12.0-py312h9d7df2b_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/sentineleof-0.11.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-80.9.0-pyhff2d567_0.conda
@@ -1793,6 +1827,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/tyro-0.9.28-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tzlocal-5.3-py312h81bd7bf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/unicodedata2-16.0.0-py312hea69d52_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/uriparser-0.9.8-h00cdb27_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.5.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
@@ -1801,6 +1836,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xerces-c-3.2.5-h92fc2f4_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxau-1.0.12-h5505292_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xorg-libxdmcp-1.1.5-hd74edd7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/xyzservices-2026.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/yamale-5.3.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h3422bc3_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yarl-1.20.1-py312h998013c_0.conda
@@ -14322,8 +14358,8 @@ packages:
   timestamp: 1769664727051
 - pypi: ./
   name: sweets
-  version: 0.2.2.post1.dev261+g38640783d
-  sha256: 0759c0b11c96ecb5cf478a7a753e50d9a96c5fa9c23e66e0f7179dc8983ed01e
+  version: 0.2.2.post1.dev266+gc7bdafeaf.d20260415
+  sha256: 01a7c9ebc3d9f9439c0c51e8ae93fa8de22054112a105f24ce6546c0c4160bc4
   requires_dist:
   - asf-search
   - burst2safe

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,8 +102,20 @@ compass = { git = "https://github.com/scottstanie/COMPASS.git", branch = "develo
 # that the sweets tropo step builds on, plus the OPERA CSLC download
 # helpers used by the OperaCslcSearch source and the NISAR GSLC helpers
 # used by NisarGslcSearch.
+# opera-utils extras are pinned explicitly rather than `[all]` because
+# `[all]` folds in the `geopandas` extra, which declares `pyogrio` and
+# `geopandas` as PyPI requirements. uv will then install those as wheels
+# on top of the conda-forge versions pixi has already provided, and the
+# pyogrio wheel crashes on `import pyogrio` with "Could not correctly
+# detect PROJ data files installed by pyogrio wheel" because it picks
+# up conda's PROJ_DATA dir, which doesn't match the wheel's bundled
+# PROJ layout. Listing only the extras sweets actually needs keeps
+# geopandas/pyogrio on the conda-forge side.
 opera-utils = { git = "https://github.com/scottstanie/opera-utils.git", branch = "develop-scott", extras = [
-  "all",
+  "asf",
+  "disp",
+  "nisar",
+  "tropo",
 ] }
 # scottstanie/dolphin@develop-scott carries the YamlModel commented-yaml
 # fix for Union-of-submodels JSON schema, which unblocks the
@@ -165,6 +177,14 @@ pysolid = "*"
 yamale = "*"
 lxml = "*"
 scipy = "*"
+# geopandas + pyogrio are hoisted here (rather than under the plotting
+# feature) so pixi's pypi-to-conda mapping marks them as satisfied for
+# *every* environment. Without this, any PyPI dep that declares a
+# `pyogrio` requirement (e.g. `opera-utils[geopandas]` pulled via an
+# `[all]` extra) causes uv to install a pyogrio wheel on top of conda's,
+# and the wheel crashes with a PROJ-data-dir mismatch on import.
+geopandas = "*"
+pyogrio = "*"
 
 [tool.pixi.tasks]
 test = "pytest"
@@ -186,7 +206,6 @@ mypy = "*"
 [tool.pixi.feature.plotting.dependencies]
 cartopy = "*"
 matplotlib = "*"
-geopandas = "*"
 ipywidgets = "*"
 
 # CPU (default) isce3 build - works on every platform sweets supports.

--- a/src/sweets/_tropo.py
+++ b/src/sweets/_tropo.py
@@ -18,8 +18,9 @@ The flow is:
    radians of phase via ``4 * pi / wavelength``, and subtract from the
    unwrapped phase. Write the corrected raster alongside the originals.
 
-The OPERA CSLC reader is registered eagerly when this module is imported,
-so any sweets code path that triggers tropo gets the backend automatically.
+The OPERA CSLC reader is registered lazily the first time
+:func:`create_tropo_corrections` runs, so importing this module stays cheap
+and does not require the ``opera_utils.tropo`` subpackage to be present.
 """
 
 from __future__ import annotations
@@ -157,7 +158,6 @@ def _force_threaded_dns_resolver() -> None:
     aiohttp.resolver.DefaultResolver = aiohttp.resolver.ThreadedResolver
 
 
-_register_opera_cslc_reader()
 _force_threaded_dns_resolver()
 
 
@@ -196,6 +196,8 @@ def create_tropo_corrections(
 
     """
     from opera_utils.tropo import create_tropo_corrections_for_stack
+
+    _register_opera_cslc_reader()
 
     options = options or TropoOptions()
     output_dir = Path(output_dir).resolve()

--- a/src/sweets/cli.py
+++ b/src/sweets/cli.py
@@ -1,129 +1,294 @@
 """Sweets command-line interface (tyro-driven).
 
-Three subcommands:
+Four subcommands:
 
-- ``sweets config``  — write a ``sweets_config.yaml`` from a few flags.
+- ``sweets config``  — write a ``sweets_config.yaml`` from CLI flags.
 - ``sweets run``     — execute a workflow from a config file.
-- ``sweets server``  — launch the (WIP) web UI server.
+- ``sweets schema``  — dump the workflow JSON schema.
+- ``sweets report``  — render an HTML report for a finished run.
 
-The CLI intentionally exposes only the most common knobs. For the long tail
-(dolphin half-window, COMPASS posting, etc.) edit the YAML directly or
-construct :class:`sweets.core.Workflow` in Python.
+``sweets config`` is a pydantic subclass of :class:`sweets.core.Workflow`,
+so every Workflow field — scalars, nested ``dolphin`` and ``tropo`` models,
+everything — is surfaced on the CLI automatically with no hand-maintained
+shadow fields. Tyro walks the pydantic schema and builds the flag layout
+from it.
+
+The one twist is ``Workflow.search``, which is a discriminated union over
+``BurstSearch | OperaCslcSearch | NisarGslcSearch``. Tyro would otherwise
+spread that across subcommand-style choices, forcing users to invoke
+``sweets config burst-search ...``. Instead, :class:`ConfigCli` hides
+``search`` from tyro with ``tyro.conf.Suppress`` and rebuilds it from a
+handful of flat, ergonomic flags (``--source``, ``--start``, ``--end``,
+``--track``, ...) in a wrap-mode validator that runs before Workflow's
+own ``_sync_aoi`` pre-validator.
+
+Every subcommand class exposes ``.execute()`` as the CLI dispatch entry
+point (rather than ``.run()``), so :class:`ConfigCli`'s entry point
+doesn't collide with :meth:`Workflow.run` inherited from the parent.
 """
 
 from __future__ import annotations
 
 import sys
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Annotated, Literal, Optional
+from typing import Annotated, Any, Literal, Optional
 
 import tyro
+from pydantic import Field, model_validator
+
+from sweets.core import Source, Workflow
 
 SourceKind = Literal["safe", "opera-cslc", "nisar-gslc"]
 
 
-@dataclass
-class ConfigCmd:
-    """Create a sweets_config.yaml from CLI arguments."""
+class ConfigCli(Workflow):
+    """Create a ``sweets_config.yaml`` from CLI arguments.
 
-    start: str
-    """Start date for the burst search (YYYY-MM-DD)."""
+    Subclass of :class:`Workflow` so every Workflow field — including
+    nested ``dolphin`` and ``tropo`` — is automatically surfaced on the
+    CLI with no redeclaration. The only additions here are:
 
-    end: str
-    """End date for the burst search (YYYY-MM-DD)."""
+    - Flat source flags (``start``, ``end``, ``source``, ``track``,
+      ``frame``, ``frequency``, ``polarizations``, ``swaths``,
+      ``out_dir``) used to build ``search`` in ``_assemble_search``
+      since the discriminated-union ``search`` field is hidden from the
+      CLI.
+    - Legacy ``do_tropo`` alias for ``--tropo.enabled``.
+    - Output-file knobs ``output`` / ``with_schema`` that only control
+      where this subcommand writes its YAML (and are not part of the
+      serialized config itself).
 
-    bbox: Optional[tuple[float, float, float, float]] = None
-    """AOI as left bottom right top in decimal degrees. One of --bbox or --wkt is required."""
+    All of these flat fields are ``exclude=True``, so dumping a
+    ``ConfigCli`` via ``to_yaml`` produces a pure Workflow YAML —
+    byte-for-byte identical to what ``Workflow.to_yaml`` would write.
+    """
 
-    wkt: Optional[str] = None
-    """AOI as a WKT polygon string, or path to a .wkt file. Overrides --bbox."""
+    # Hide the discriminated-union `search` from tyro; we rebuild it
+    # from the flat source flags in `_assemble_search` below. The
+    # `type: ignore` is because we're narrowing a required field to an
+    # Optional one in the subclass. A non-empty description is required
+    # so dolphin's YAML-comment writer (which walks the full schema,
+    # including excluded fields) doesn't trip over a missing key.
+    search: Annotated[Optional[Source], tyro.conf.Suppress] = Field(  # type: ignore[assignment]
+        default=None,
+        description=(
+            "Source of input SLCs. Built by `_assemble_search` from the"
+            " flat `--source`/`--start`/`--track`/... flags; hidden from"
+            " the CLI because it's a discriminated union."
+        ),
+    )
 
-    source: SourceKind = "safe"
-    """Where the input SLCs come from. `safe` (default): raw S1 bursts via burst2safe + COMPASS. `opera-cslc`: pre-made OPERA CSLC HDF5s from ASF. `nisar-gslc`: pre-made NISAR GSLC HDF5s via CMR (L-band, UTM, already geocoded)."""
+    # Workflow declares these with `default_factory=lambda data: ...`
+    # that reads already-validated data (for `<work_dir>/dem.tif` etc.).
+    # Tyro materializes defaults at parse time before any data exists,
+    # so it can't call those factories — we override with plain
+    # `Optional[Path] = None` and the wrap validator strips them when
+    # unset so Workflow's own factory takes over downstream.
+    dem_filename: Optional[Path] = Field(  # type: ignore[assignment]
+        default=None,
+        description=(
+            "DEM raster in EPSG:4326. Defaults to `<work_dir>/dem.tif`"
+            " (downloaded via sardem)."
+        ),
+    )
+    water_mask_filename: Optional[Path] = Field(  # type: ignore[assignment]
+        default=None,
+        description=(
+            "Water mask in EPSG:4326 (uint8, 1=land, 0=water). Defaults"
+            " to `<work_dir>/watermask.tif` (derived from the DEM)."
+        ),
+    )
 
-    track: Optional[int] = None
-    """Relative orbit / track number. Required for --source safe; optional but recommended for --source opera-cslc and --source nisar-gslc. For NISAR this is the `Track` field on ASF Vertex (the RRR digits in the granule filename)."""
+    # --- Source-flat flags (folded into `search`, not dumped) ---
 
-    frame: Optional[int] = None
-    """NISAR track-frame number — the `Frame` field on ASF Vertex (the TTT digits in the granule filename, e.g. `71`). Only honored by --source nisar-gslc."""
+    start: str = Field(
+        ...,
+        description="Start date for the burst search (YYYY-MM-DD).",
+        exclude=True,
+    )
+    end: str = Field(
+        ...,
+        description="End date for the burst search (YYYY-MM-DD).",
+        exclude=True,
+    )
+    source: SourceKind = Field(
+        default="safe",
+        description=(
+            "Where the input SLCs come from. `safe` (default): raw S1"
+            " bursts via burst2safe + COMPASS. `opera-cslc`: pre-made"
+            " OPERA CSLC HDF5s from ASF. `nisar-gslc`: pre-made NISAR"
+            " GSLC HDF5s via CMR (L-band, UTM, already geocoded)."
+        ),
+        exclude=True,
+    )
+    track: Optional[int] = Field(
+        default=None,
+        description=(
+            "Relative orbit / track number. Required for --source safe;"
+            " optional but recommended for opera-cslc and nisar-gslc."
+            " For NISAR this is the `Track` field on ASF Vertex (the"
+            " RRR digits in the granule filename)."
+        ),
+        exclude=True,
+    )
+    frame: Optional[int] = Field(
+        default=None,
+        description=(
+            "NISAR track-frame number — the `Frame` field on ASF Vertex"
+            " (the TTT digits in the granule filename, e.g. `71`). Only"
+            " honored by --source nisar-gslc."
+        ),
+        exclude=True,
+    )
+    frequency: Literal["A", "B"] = Field(
+        default="A",
+        description=(
+            "NISAR frequency band (`A` = L-band, `B` reserved). Only"
+            " honored by --source nisar-gslc."
+        ),
+        exclude=True,
+    )
+    polarizations: list[str] = Field(
+        default_factory=lambda: ["VV"],
+        description=(
+            "Polarizations to keep. Defaults to ['VV'] for S1/OPERA;"
+            " pass --polarizations HH for NISAR."
+        ),
+        exclude=True,
+    )
+    swaths: Optional[list[str]] = Field(
+        default=None,
+        description=(
+            "Restrict to specific subswaths (e.g. ['IW2']). Only"
+            " honored by --source safe."
+        ),
+        exclude=True,
+    )
+    out_dir: Path = Field(
+        default_factory=lambda: Path("data"),
+        description="Where downloaded SLC inputs will live.",
+        exclude=True,
+    )
 
-    frequency: Literal["A", "B"] = "A"
-    """NISAR frequency band (`A` = L-band, `B` reserved). Only honored by --source nisar-gslc."""
+    do_tropo: bool = Field(
+        default=False,
+        description=(
+            "Alias for `--tropo.enabled`. Kept for backwards"
+            " compatibility with pre-refactor README/docs."
+        ),
+        exclude=True,
+    )
 
-    out_dir: Path = field(default_factory=lambda: Path("data"))
-    """Where downloaded SLC inputs will live."""
+    # --- CLI-only output knobs (not serialized) ---
 
-    work_dir: Path = field(default_factory=Path.cwd)
-    """Top-level working directory for the workflow."""
+    output: Path = Field(
+        default=Path("sweets_config.yaml"),
+        description="Where to write the config file.",
+        exclude=True,
+    )
+    with_schema: bool = Field(
+        default=True,
+        description=(
+            "Also write a sibling `<output>.schema.json` and prepend a"
+            " `# yaml-language-server: $schema=...` modeline. Editors"
+            " with the YAML Language Server (VS Code, Neovim-yamlls,"
+            " JetBrains, etc.) use that for inline hover docs,"
+            " autocomplete, and validation. Pass --no-with-schema to"
+            " skip."
+        ),
+        exclude=True,
+    )
 
-    polarizations: list[str] = field(default_factory=lambda: ["VV"])
-    """Polarizations to keep. Defaults to ['VV'] for S1/OPERA; pass --polarizations HH for NISAR."""
+    @model_validator(mode="wrap")
+    @classmethod
+    def _assemble_search(cls, data: Any, handler: Any) -> Any:
+        """Build ``search`` from the flat source flags before the rest of validation.
 
-    swaths: Optional[list[str]] = None
-    """Restrict to specific subswaths (e.g. ['IW2']). Only honored by --source safe."""
+        ``mode="wrap"`` runs around the entire validation pipeline, so
+        the input dict is mutated before Workflow's mode="before"
+        ``_sync_aoi`` validator sees it. That matters because
+        ``_sync_aoi`` would crash on a missing / None ``search`` value;
+        we need it to receive a fully-formed dict that encodes the flat
+        CLI flags.
 
-    n_workers: int = 4
-    """Process pool size for COMPASS geocoding (--source safe only)."""
+        The flat-flag path only triggers when the caller provided one
+        of ``start`` / ``source`` (i.e. it's a CLI instantiation).
+        Loading a serialized YAML via ``from_yaml`` passes ``search``
+        directly and skips this branch entirely.
+        """
+        if isinstance(data, dict) and ("start" in data or "source" in data):
+            data = dict(data)
+            src = data.get("source", "safe")
+            search: dict[str, Any] = {
+                "kind": src,
+                "start": data.get("start", ""),
+                "end": data.get("end", ""),
+                "out_dir": data.get("out_dir", Path("data")),
+            }
+            if src == "safe":
+                if data.get("track") is None:
+                    msg = "--track is required for --source safe"
+                    raise ValueError(msg)
+                search["track"] = data["track"]
+                search["polarizations"] = data.get("polarizations", ["VV"])
+                if data.get("swaths") is not None:
+                    search["swaths"] = data["swaths"]
+            elif src == "opera-cslc":
+                if data.get("track") is not None:
+                    search["track"] = data["track"]
+            elif src == "nisar-gslc":
+                if data.get("track") is not None:
+                    search["track"] = data["track"]
+                if data.get("frame") is not None:
+                    search["frame"] = data["frame"]
+                search["frequency"] = data.get("frequency", "A")
+                search["polarizations"] = data.get("polarizations", ["VV"])
+            data["search"] = search
 
-    do_tropo: bool = False
-    """Run the OPERA L4 TROPO-ZENITH correction step after dolphin (off by default; not supported with --source nisar-gslc)."""
+            if data.get("do_tropo"):
+                tropo_obj: Any = data.get("tropo")
+                dump = getattr(tropo_obj, "model_dump", None)
+                if callable(dump):
+                    tropo_dict: dict[str, Any] = dump()
+                elif tropo_obj is None:
+                    tropo_dict = {}
+                else:
+                    tropo_dict = dict(tropo_obj)
+                tropo_dict["enabled"] = True
+                data["tropo"] = tropo_dict
 
-    output: Path = Path("sweets_config.yaml")
-    """Where to write the config file."""
+            # Strip CLI-only None overrides for fields whose Workflow
+            # default_factory builds a `<work_dir>/...` path — leaving
+            # them as None would override Workflow's factory with None.
+            for key in ("dem_filename", "water_mask_filename"):
+                if data.get(key) is None:
+                    data.pop(key, None)
 
-    with_schema: bool = True
-    """Also write a sibling `<output>.schema.json` next to the YAML and
-    prepend a `# yaml-language-server: $schema=...` modeline. Editors
-    with the YAML Language Server (VS Code, Neovim-yamlls, JetBrains,
-    etc.) use that to provide inline hover docs, autocomplete, and
-    validation for every field in the sweets config. Pass
-    --no-with-schema to skip."""
+        return handler(data)
 
-    def run(self) -> None:
-        """Build and dump a Workflow config to YAML."""
-        # Heavy imports go here so `sweets --help` is snappy.
-        from sweets.core import Workflow
+    def execute(self) -> None:
+        """Write the config YAML (and, optionally, its schema sidecar).
 
+        Serializes via a fresh :class:`Workflow` instance rather than
+        dumping ``self`` directly. That matters because ConfigCli
+        overrides ``dem_filename`` / ``water_mask_filename`` as
+        ``Optional[Path] = None`` (tyro can't materialize Workflow's
+        own ``default_factory=lambda data: ...`` at parse time), so
+        dumping ``self`` would serialize ``null`` for those fields and
+        a later ``Workflow.from_yaml`` would reject them. Stripping the
+        None values and going through ``Workflow.model_validate`` lets
+        Workflow's own defaults produce concrete ``<work_dir>/...``
+        paths in the YAML.
+        """
         if self.bbox is None and self.wkt is None:
             print("error: one of --bbox or --wkt is required", file=sys.stderr)
             raise SystemExit(2)
-
-        search: dict = {
-            "kind": self.source,
-            "start": self.start,
-            "end": self.end,
-            "out_dir": self.out_dir,
-        }
-        if self.source == "safe":
-            if self.track is None:
-                print("error: --track is required for --source safe", file=sys.stderr)
-                raise SystemExit(2)
-            search["track"] = self.track
-            search["polarizations"] = self.polarizations
-            search["swaths"] = self.swaths
-        elif self.source == "opera-cslc":
-            # `track` is optional on OPERA — ASF will filter on AOI alone.
-            if self.track is not None:
-                search["track"] = self.track
-        elif self.source == "nisar-gslc":
-            if self.track is not None:
-                search["track"] = self.track
-            if self.frame is not None:
-                search["frame"] = self.frame
-            search["frequency"] = self.frequency
-            search["polarizations"] = self.polarizations
-
-        workflow = Workflow.model_validate(
-            {
-                "bbox": self.bbox,
-                "wkt": self.wkt,
-                "work_dir": self.work_dir,
-                "n_workers": self.n_workers,
-                "search": search,
-                "tropo": {"enabled": self.do_tropo},
-            }
-        )
+        payload = self.model_dump(by_alias=True)
+        for key in ("dem_filename", "water_mask_filename"):
+            if payload.get(key) is None:
+                payload.pop(key, None)
+        workflow = Workflow.model_validate(payload)
         workflow.to_yaml(self.output)
         if self.with_schema:
             _emit_schema_sidecar(self.output)
@@ -133,16 +298,14 @@ class ConfigCmd:
 def _emit_schema_sidecar(yaml_path: Path) -> None:
     """Write a JSON schema next to the YAML and add a modeline comment.
 
-    The schema is `Workflow.model_json_schema()` emitted verbatim; pydantic
-    produces JSON Schema Draft 2020-12 with a `oneOf + discriminator` for
-    the `Workflow.search` field, which the YAML Language Server handles
-    natively. The modeline is read by the redhat.vscode-yaml extension
-    (and every editor that speaks yamlls) to attach the schema at load
-    time.
+    The schema is ``Workflow.model_json_schema()`` emitted verbatim;
+    pydantic produces JSON Schema Draft 2020-12 with a ``oneOf +
+    discriminator`` for the ``Workflow.search`` field, which the YAML
+    Language Server handles natively. The modeline is read by the
+    redhat.vscode-yaml extension (and every editor that speaks yamlls)
+    to attach the schema at load time.
     """
     import json
-
-    from sweets.core import Workflow
 
     schema_path = yaml_path.with_suffix(yaml_path.suffix + ".schema.json")
     schema_path.write_text(json.dumps(Workflow.model_json_schema(), indent=2) + "\n")
@@ -158,10 +321,8 @@ def _emit_schema_sidecar(yaml_path: Path) -> None:
 class SchemaCmd:
     """Dump the JSON schema for the sweets workflow config to stdout."""
 
-    def run(self) -> None:
+    def execute(self) -> None:
         import json
-
-        from sweets.core import Workflow
 
         print(json.dumps(Workflow.model_json_schema(), indent=2))
 
@@ -178,7 +339,7 @@ class ReportCmd:
     output: Optional[Path] = None
     """Where to write the report. Defaults to `<work_dir>/sweets_report.html`."""
 
-    def run(self) -> None:
+    def execute(self) -> None:
         from sweets._report import build_report
 
         path = build_report(
@@ -198,10 +359,8 @@ class RunCmd:
     starting_step: int = 1
     """Skip earlier stages (1=download, 2=geocode, 3=dolphin)."""
 
-    def run(self) -> None:
+    def execute(self) -> None:
         """Load the workflow and run it."""
-        from sweets.core import Workflow
-
         if not self.config_file.exists():
             msg = f"config file {self.config_file} does not exist"
             raise SystemExit(msg)
@@ -213,7 +372,7 @@ def main() -> None:
     """Top-level CLI entry point."""
     cmd = tyro.extras.subcommand_cli_from_dict(
         {
-            "config": ConfigCmd,
+            "config": ConfigCli,
             "run": RunCmd,
             "schema": SchemaCmd,
             "report": ReportCmd,
@@ -221,7 +380,7 @@ def main() -> None:
         prog="sweets",
         description="Sentinel-1 InSAR workflow runner.",
     )
-    cmd.run()
+    cmd.execute()
 
 
 if __name__ == "__main__":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,335 @@
+"""Tests for the sweets CLI layer — specifically :class:`ConfigCli`.
+
+The CLI-facing subclass is subtle enough to deserve its own tests:
+
+- a ``mode="wrap"`` validator re-assembles the discriminated-union
+  ``search`` field from flat ``--source`` / ``--start`` / ``--track``
+  flags before Workflow's own validators run;
+- ``dem_filename`` / ``water_mask_filename`` are re-declared as
+  ``Optional[Path] = None`` to work around a tyro limitation, but still
+  need to fall back to Workflow's ``<work_dir>/...`` defaults after the
+  CLI has gone through ``execute()``;
+- flat source flags are ``exclude=True`` so they must not leak into the
+  serialized YAML — the YAML on disk has to be a byte-equivalent pure
+  Workflow.
+
+These tests avoid touching ASF, COMPASS, or dolphin — they exercise
+ConfigCli's validation and YAML-dump logic end-to-end, and run
+``tyro.cli(ConfigCli, args=...)`` once to catch regressions in the
+parser wiring.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import tyro
+import yaml  # type: ignore[import-untyped]
+from pydantic import ValidationError
+
+from sweets._dolphin import DolphinOptions
+from sweets._tropo import TropoOptions
+from sweets.cli import ConfigCli
+from sweets.core import Workflow
+from sweets.download import BurstSearch, NisarGslcSearch, OperaCslcSearch
+
+
+@pytest.fixture
+def bbox() -> tuple[float, float, float, float]:
+    return (-104.0, 32.0, -103.0, 33.0)
+
+
+@pytest.fixture
+def safe_kwargs(
+    tmp_path: Path, bbox: tuple[float, float, float, float]
+) -> dict[str, Any]:
+    """Minimum kwargs for a valid `--source safe` ConfigCli instance."""
+    return {
+        "start": "2023-01-01",
+        "end": "2023-02-01",
+        "source": "safe",
+        "track": 78,
+        "bbox": bbox,
+        "work_dir": tmp_path,
+        "out_dir": tmp_path / "data",
+    }
+
+
+class TestAssembleSearch:
+    """The `mode="wrap"` validator that builds `search` from flat flags."""
+
+    def test_safe_source_builds_burst_search(self, safe_kwargs):
+        cfg = ConfigCli(**safe_kwargs)
+        assert isinstance(cfg.search, BurstSearch)
+        assert cfg.search.kind == "safe"
+        assert cfg.search.track == 78
+        assert cfg.search.polarizations == ["VV"]
+
+    def test_safe_custom_polarizations_and_swaths(self, safe_kwargs):
+        cfg = ConfigCli(
+            **safe_kwargs,
+            polarizations=["VV", "VH"],
+            swaths=["IW2"],
+        )
+        assert isinstance(cfg.search, BurstSearch)
+        assert cfg.search.polarizations == ["VV", "VH"]
+        assert cfg.search.swaths == ["IW2"]
+
+    def test_opera_cslc_source(self, tmp_path, bbox):
+        cfg = ConfigCli(
+            start="2023-01-01",
+            end="2023-02-01",
+            source="opera-cslc",
+            bbox=bbox,
+            work_dir=tmp_path,
+            out_dir=tmp_path / "data",
+        )
+        assert isinstance(cfg.search, OperaCslcSearch)
+        assert cfg.search.kind == "opera-cslc"
+
+    def test_opera_cslc_track_optional_but_preserved(self, tmp_path, bbox):
+        cfg = ConfigCli(
+            start="2023-01-01",
+            end="2023-02-01",
+            source="opera-cslc",
+            track=71,
+            bbox=bbox,
+            work_dir=tmp_path,
+            out_dir=tmp_path / "data",
+        )
+        assert isinstance(cfg.search, OperaCslcSearch)
+        assert cfg.search.track == 71
+
+    def test_nisar_gslc_source(self, tmp_path, bbox):
+        cfg = ConfigCli(
+            start="2023-01-01",
+            end="2023-02-01",
+            source="nisar-gslc",
+            track=101,
+            frame=71,
+            frequency="A",
+            polarizations=["HH"],
+            bbox=bbox,
+            work_dir=tmp_path,
+            out_dir=tmp_path / "data",
+        )
+        assert isinstance(cfg.search, NisarGslcSearch)
+        assert cfg.search.track == 101
+        assert cfg.search.frame == 71
+        assert cfg.search.frequency == "A"
+        assert cfg.search.polarizations == ["HH"]
+
+    def test_safe_requires_track(self, tmp_path, bbox):
+        with pytest.raises(
+            ValidationError, match="--track is required for --source safe"
+        ):
+            ConfigCli(
+                start="2023-01-01",
+                end="2023-02-01",
+                source="safe",
+                bbox=bbox,
+                work_dir=tmp_path,
+                out_dir=tmp_path / "data",
+            )
+
+    def test_missing_aoi_raises(self, tmp_path):
+        with pytest.raises(ValidationError, match="bbox.*wkt"):
+            ConfigCli(
+                start="2023-01-01",
+                end="2023-02-01",
+                source="safe",
+                track=78,
+                work_dir=tmp_path,
+                out_dir=tmp_path / "data",
+            )
+
+
+class TestLegacyDoTropo:
+    """The `--do-tropo` alias must keep working for README / notebook examples."""
+
+    def test_do_tropo_true_sets_tropo_enabled(self, safe_kwargs):
+        cfg = ConfigCli(**safe_kwargs, do_tropo=True)
+        assert cfg.tropo.enabled is True
+
+    def test_do_tropo_false_leaves_tropo_disabled(self, safe_kwargs):
+        cfg = ConfigCli(**safe_kwargs, do_tropo=False)
+        assert cfg.tropo.enabled is False
+
+    def test_nested_tropo_enabled_directly(self, safe_kwargs):
+        cfg = ConfigCli(**safe_kwargs, tropo=TropoOptions(enabled=True))
+        assert cfg.tropo.enabled is True
+
+
+class TestNestedOverrides:
+    """Nested pydantic sub-configs round-trip through instantiation."""
+
+    def test_custom_dolphin_half_window(self, safe_kwargs):
+        cfg = ConfigCli(
+            **safe_kwargs,
+            dolphin=DolphinOptions(half_window=(20, 10), unwrap_method="spurt"),
+        )
+        assert cfg.dolphin.half_window == (20, 10)
+        assert cfg.dolphin.unwrap_method == "spurt"
+
+    def test_slc_posting_override(self, safe_kwargs):
+        cfg = ConfigCli(**safe_kwargs, slc_posting=(10, 2.5))
+        assert cfg.slc_posting == (10, 2.5)
+
+
+class TestExecuteRoundTrip:
+    """``execute()`` writes a YAML that reloads as a pure Workflow."""
+
+    def test_reloads_with_user_overrides_preserved(self, safe_kwargs, tmp_path):
+        output = tmp_path / "config.yaml"
+        cfg = ConfigCli(
+            **safe_kwargs,
+            slc_posting=(10, 2.5),
+            dolphin=DolphinOptions(half_window=(20, 10), unwrap_method="spurt"),
+            tropo=TropoOptions(enabled=True),
+            output=output,
+            with_schema=False,
+        )
+        cfg.execute()
+
+        reloaded = Workflow.from_yaml(output)
+        assert reloaded.slc_posting == (10, 2.5)
+        assert reloaded.dolphin.half_window == (20, 10)
+        assert reloaded.dolphin.unwrap_method == "spurt"
+        assert reloaded.tropo.enabled is True
+        assert reloaded.search.kind == "safe"
+        assert reloaded.search.track == 78
+
+    def test_default_paths_computed_from_work_dir(self, safe_kwargs, tmp_path):
+        """dem_filename / water_mask_filename default to <work_dir>/*.tif."""
+        output = tmp_path / "config.yaml"
+        cfg = ConfigCli(**safe_kwargs, output=output, with_schema=False)
+        cfg.execute()
+
+        reloaded = Workflow.from_yaml(output)
+        assert reloaded.dem_filename == tmp_path / "dem.tif"
+        assert reloaded.water_mask_filename == tmp_path / "watermask.tif"
+
+    def test_user_path_overrides_preserved(self, safe_kwargs, tmp_path):
+        output = tmp_path / "config.yaml"
+        my_dem = tmp_path / "my_dem.tif"
+        my_mask = tmp_path / "my_mask.tif"
+        cfg = ConfigCli(
+            **safe_kwargs,
+            dem_filename=my_dem,
+            water_mask_filename=my_mask,
+            output=output,
+            with_schema=False,
+        )
+        cfg.execute()
+
+        reloaded = Workflow.from_yaml(output)
+        assert reloaded.dem_filename == my_dem
+        assert reloaded.water_mask_filename == my_mask
+
+    def test_flat_cli_fields_not_serialized(self, safe_kwargs, tmp_path):
+        """Flat source flags and CLI-only knobs must not appear in the YAML.
+
+        They're CLI input sugar — the canonical state lives on ``search``
+        (for source details) or on nothing at all (for ``output``,
+        ``with_schema``). If any of them leaked into the dumped YAML,
+        round-tripping through ``Workflow.from_yaml`` would either break
+        or silently retain CLI-only state across reloads.
+        """
+        output = tmp_path / "config.yaml"
+        cfg = ConfigCli(**safe_kwargs, output=output, with_schema=False)
+        cfg.execute()
+
+        raw = yaml.safe_load(output.read_text())
+        flat_keys = {
+            "start",
+            "end",
+            "source",
+            "track",
+            "frame",
+            "frequency",
+            "polarizations",
+            "swaths",
+            "out_dir",
+            "do_tropo",
+            "output",
+            "with_schema",
+        }
+        leaked = flat_keys & set(raw.keys())
+        assert not leaked, f"flat CLI fields leaked into YAML top level: {leaked}"
+        # Sanity: the canonical state is present on `search` instead.
+        # `track` serializes through BurstSearch's `relativeOrbit` alias.
+        assert raw["search"]["kind"] == "safe"
+        assert raw["search"]["relativeOrbit"] == 78
+
+    def test_schema_sidecar_written(self, safe_kwargs, tmp_path):
+        output = tmp_path / "config.yaml"
+        cfg = ConfigCli(**safe_kwargs, output=output, with_schema=True)
+        cfg.execute()
+
+        sidecar = output.with_suffix(output.suffix + ".schema.json")
+        assert sidecar.exists()
+        assert output.read_text().startswith("# yaml-language-server: $schema=")
+
+
+class TestTyroIntegration:
+    """End-to-end: run through `tyro.cli` so the argparse wiring is exercised."""
+
+    def test_parses_nested_dolphin_and_tropo_flags(self, tmp_path):
+        output = tmp_path / "config.yaml"
+        args = [
+            "--start",
+            "2023-01-01",
+            "--end",
+            "2023-02-01",
+            "--bbox",
+            "-104",
+            "32",
+            "-103",
+            "33",
+            "--source",
+            "opera-cslc",
+            "--slc-posting",
+            "10",
+            "2.5",
+            "--dolphin.half-window",
+            "20",
+            "10",
+            "--dolphin.unwrap-method",
+            "spurt",
+            "--tropo.enabled",
+            "--work-dir",
+            str(tmp_path),
+            "--out-dir",
+            str(tmp_path / "data"),
+            "--output",
+            str(output),
+            "--no-with-schema",
+        ]
+        cfg = tyro.cli(ConfigCli, args=args)
+        assert cfg.slc_posting == (10, 2.5)
+        assert cfg.dolphin.half_window == (20, 10)
+        assert cfg.dolphin.unwrap_method == "spurt"
+        assert cfg.tropo.enabled is True
+        search = cfg.search
+        assert isinstance(search, OperaCslcSearch)
+        assert search.kind == "opera-cslc"
+
+        cfg.execute()
+        assert output.exists()
+        reloaded = Workflow.from_yaml(output)
+        assert reloaded.dolphin.unwrap_method == "spurt"
+
+    def test_search_field_suppressed_from_help(self, capsys):
+        """`tyro.conf.Suppress` should keep `--search` out of the help text."""
+        with pytest.raises(SystemExit):
+            tyro.cli(ConfigCli, args=["--help"])
+        out = capsys.readouterr().out
+        # The discriminated-union `search` field must be hidden — if it
+        # leaks back into the CLI it'll be spread across subcommand-style
+        # choices and break the flat-flag UX.
+        assert "--search" not in out
+        # Nested groups should still be present.
+        assert "--dolphin.half-window" in out
+        assert "--tropo.enabled" in out


### PR DESCRIPTION
- Our restricted set of dolphin options were not changeable from `sweets config`
- Fixes from problems with dependencies/tropo imports seen in the feedstock